### PR TITLE
Impl display

### DIFF
--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -1,12 +1,12 @@
 use log::{debug, info, warn};
-use std::os::unix::net::{UnixDatagram ,SocketAddr};
+use std::os::unix::net::{SocketAddr, UnixDatagram};
 use std::process;
 
-use dplane_rpc::log::init_dplane_rpc_log;
-use dplane_rpc::socks::{send_msg, ux_sock_bind};
-use dplane_rpc::msg::*;
-use dplane_rpc::wire::Wire;
 use bytes::Bytes;
+use dplane_rpc::log::init_dplane_rpc_log;
+use dplane_rpc::msg::*;
+use dplane_rpc::socks::{send_msg, ux_sock_bind};
+use dplane_rpc::wire::Wire;
 
 fn process_rx_data(sock: &UnixDatagram, peer: &SocketAddr, data: &[u8]) {
     let mut buf_rx = Bytes::copy_from_slice(data);
@@ -17,7 +17,7 @@ fn process_rx_data(sock: &UnixDatagram, peer: &SocketAddr, data: &[u8]) {
                 process::exit(0)
             }
             send_msg(sock, &msg, peer)
-        },
+        }
         Err(e) => panic!("Error decoding message received from {:?}: {:?}", peer, e),
     }
 }
@@ -34,7 +34,7 @@ fn main() {
             Ok((len, peer)) => {
                 debug!("Received {} octets of data from {:?}...", len, &peer);
                 process_rx_data(&sock, &peer, &buf[..len]);
-            },
+            }
             Err(e) => {
                 panic!("Error receiving from unix sock: {}", e);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,6 @@ mod tests;
 pub mod log;
 
 /*
-  Sock utils
- */
+ Sock utils
+*/
 pub mod socks;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,26 +1,24 @@
 pub use log::{debug, error, info, warn};
 pub use tracing::Level;
 
-pub fn init_dplane_rpc_log(loglevel: tracing::Level)
-{
+pub fn init_dplane_rpc_log(loglevel: tracing::Level) {
     if loglevel == tracing::Level::DEBUG {
         tracing_subscriber::fmt()
-        .with_level(true)
-        .with_max_level(loglevel)
-        .with_target(true)
-        .with_thread_ids(true)
-        .pretty()
-        .compact()
-        .init();
+            .with_level(true)
+            .with_max_level(loglevel)
+            .with_target(true)
+            .with_thread_ids(true)
+            .pretty()
+            .compact()
+            .init();
     } else {
         tracing_subscriber::fmt()
-        .with_level(true)
-        .with_max_level(loglevel)
-        .with_target(false)
-        .with_thread_ids(false)
-        .with_line_number(false)
-        .compact()
-        .init();
+            .with_level(true)
+            .with_max_level(loglevel)
+            .with_target(false)
+            .with_thread_ids(false)
+            .with_line_number(false)
+            .compact()
+            .init();
     }
-
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,6 +1,6 @@
-use std::fmt::Display;
 pub use crate::objects::*;
 use crate::wire::WireError;
+use std::fmt::Display;
 
 /* Msg definitions */
 #[doc = "A request message"]
@@ -211,18 +211,18 @@ impl WrapMsg for RpcControl {
 /* Display for terser logs */
 impl Display for RpcRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f,"Request #{} {:?}", self.seqn, self.op)?;
+        write!(f, "Request #{} {:?}", self.seqn, self.op)?;
         if let Some(object) = &self.obj {
-            write!(f," {}", object)?;
+            write!(f, " {}", object)?;
         }
         Ok(())
     }
 }
 impl Display for RpcResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f,"Response to #{} result: {:?}", self.seqn, self.rescode)?;
+        write!(f, "Response to #{} result: {:?}", self.seqn, self.rescode)?;
         for object in &self.objs {
-            write!(f," {}", object)?;
+            write!(f, " {}", object)?;
         }
         Ok(())
     }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
 pub use crate::proto::*;
 use crate::wire::WireError;
 pub use mac_address::MacAddress;
+use std::fmt::Display;
 pub use std::net::IpAddr;
 
 #[doc = "A versioning information object."]
@@ -119,7 +119,13 @@ impl Rmac {
 }
 impl IfAddress {
     #[allow(dead_code)]
-    pub fn new(ifname: String, address: IpAddr, mask_len: MaskLen, ifindex: Ifindex, vrfid: VrfId) -> Self {
+    pub fn new(
+        ifname: String,
+        address: IpAddr,
+        mask_len: MaskLen,
+        ifindex: Ifindex,
+        vrfid: VrfId,
+    ) -> Self {
         Self {
             ifname,
             address,
@@ -153,7 +159,11 @@ impl IpRoute {
 /* Display for terser logs */
 impl Display for VerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Verinfo ─── v{}.{}.{}", self.major, self.minor, self.patch)
+        write!(
+            f,
+            "Verinfo ─── v{}.{}.{}",
+            self.major, self.minor, self.patch
+        )
     }
 }
 impl Display for Rmac {
@@ -177,7 +187,7 @@ impl Display for IfAddress {
 impl Display for NextHopEncap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NextHopEncap::VXLAN(e)=> {
+            NextHopEncap::VXLAN(e) => {
                 write!(f, "Vxlan (vni:{})", e.vni)
             }
         }
@@ -203,15 +213,20 @@ impl Display for NextHop {
 }
 impl Display for IpRoute {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "IpRoute ─── vrf:{} tbl:{} {:?}[{}/{}] {}/{}",
-            self.vrfid, self.tableid,
+        write!(
+            f,
+            "IpRoute ─── vrf:{} tbl:{} {:?}[{}/{}] {}/{}",
+            self.vrfid,
+            self.tableid,
             self.rtype,
             self.distance,
             self.metric,
-            self.prefix, self.prefix_len)?;
+            self.prefix,
+            self.prefix_len
+        )?;
 
         for nhop in &self.nhops {
-            write!(f," {}", nhop)?;
+            write!(f, " {}", nhop)?;
         }
         Ok(())
     }
@@ -233,11 +248,11 @@ impl Display for GetFilter {
 impl Display for RpcObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RpcObject::VerInfo(o)=> o.fmt(f),
+            RpcObject::VerInfo(o) => o.fmt(f),
             RpcObject::IfAddress(o) => o.fmt(f),
             RpcObject::Rmac(o) => o.fmt(f),
             RpcObject::IpRoute(o) => o.fmt(f),
-            RpcObject::GetFilter(o)=> o.fmt(f),
+            RpcObject::GetFilter(o) => o.fmt(f),
         }
     }
 }

--- a/src/socks.rs
+++ b/src/socks.rs
@@ -1,12 +1,12 @@
-use log::{debug, error, trace};
-use std::os::unix::fs::PermissionsExt;
-pub use std::os::unix::net::UnixDatagram;
-pub use std::os::unix::net::SocketAddr;
-use std::fs;
-use std::path::Path;
-use bytes::BytesMut;
 use crate::msg::RpcMsg;
 use crate::wire::Wire;
+use bytes::BytesMut;
+use log::{debug, error, trace};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+pub use std::os::unix::net::SocketAddr;
+pub use std::os::unix::net::UnixDatagram;
+use std::path::Path;
 
 pub fn ux_sock_bind(path: impl AsRef<Path>) -> std::io::Result<UnixDatagram> {
     let path = path.as_ref();
@@ -16,7 +16,7 @@ pub fn ux_sock_bind(path: impl AsRef<Path>) -> std::io::Result<UnixDatagram> {
         let mut perms = fs::metadata(path)?.permissions();
         perms.set_mode(0o777);
         /* may alternatively use perms.set_readonly(false),
-           but clippy complains */
+        but clippy complains */
         fs::set_permissions(path, perms)?;
     }
     sock
@@ -26,14 +26,12 @@ pub fn send_msg(sock: &UnixDatagram, msg: &RpcMsg, peer: &SocketAddr) {
     debug!("Sending {}", msg);
     let mut buf = BytesMut::with_capacity(128);
     match msg.encode(&mut buf) {
-        Ok(_) => {
-            match sock.send_to_addr(&buf, peer) {
-                Ok(len) => {
-                    trace!("Sent {} octets to {:?}", len, peer);
-                },
-                Err(e) => {
-                    error!("Failed to send data to {:?}:{}", peer, e)
-                },
+        Ok(_) => match sock.send_to_addr(&buf, peer) {
+            Ok(len) => {
+                trace!("Sent {} octets to {:?}", len, peer);
+            }
+            Err(e) => {
+                error!("Failed to send data to {:?}:{}", peer, e)
             }
         },
         Err(e) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,8 +44,7 @@ mod positive_tests {
             minor: 66,
             patch: 99,
         };
-        let req = RpcRequest::new(RpcOp::Connect, 999)
-        .set_object(RpcObject::VerInfo(verinfo));
+        let req = RpcRequest::new(RpcOp::Connect, 999).set_object(RpcObject::VerInfo(verinfo));
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
     }
@@ -57,8 +56,7 @@ mod positive_tests {
             MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
             3000,
         );
-        let req = RpcRequest::new(RpcOp::Add, 98765)
-        .set_object(RpcObject::Rmac(rmac));
+        let req = RpcRequest::new(RpcOp::Add, 98765).set_object(RpcObject::Rmac(rmac));
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
     }
@@ -66,8 +64,7 @@ mod positive_tests {
     #[test]
     fn test_rpcmsg_request_ifaddr() {
         let ifaddress = IfAddress::new("eth0".to_owned(), "10.0.0.1".parse().unwrap(), 30, 987, 13);
-        let req = RpcRequest::new(RpcOp::Del, 11223344)
-        .set_object(RpcObject::IfAddress(ifaddress));
+        let req = RpcRequest::new(RpcOp::Del, 11223344).set_object(RpcObject::IfAddress(ifaddress));
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
     }
@@ -93,8 +90,7 @@ mod positive_tests {
         };
         assert_eq!(route.add_next_hop(nhop), Ok(()));
 
-        let req = RpcRequest::new(RpcOp::Update, 3210)
-        .set_object(RpcObject::IpRoute(route));
+        let req = RpcRequest::new(RpcOp::Update, 3210).set_object(RpcObject::IpRoute(route));
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
     }
@@ -120,8 +116,7 @@ mod positive_tests {
         };
         assert_eq!(route.add_next_hop(nhop), Ok(()));
 
-        let req = RpcRequest::new(RpcOp::Update, 3210)
-        .set_object(RpcObject::IpRoute(route));
+        let req = RpcRequest::new(RpcOp::Update, 3210).set_object(RpcObject::IpRoute(route));
 
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
@@ -155,8 +150,7 @@ mod positive_tests {
         };
         assert_eq!(route.add_next_hop(nhop), Ok(()));
 
-        let req = RpcRequest::new(RpcOp::Add, 7777)
-        .set_object(RpcObject::IpRoute(route));
+        let req = RpcRequest::new(RpcOp::Add, 7777).set_object(RpcObject::IpRoute(route));
 
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
@@ -193,8 +187,7 @@ mod positive_tests {
             nhops: vec![],
         };
         assert_eq!(add_next_hops(&mut route, 10, 20), Ok(()));
-        let req = RpcRequest::new(RpcOp::Add, 7777)
-        .set_object(RpcObject::IpRoute(route));
+        let req = RpcRequest::new(RpcOp::Add, 7777).set_object(RpcObject::IpRoute(route));
 
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
@@ -237,7 +230,13 @@ mod positive_tests {
             3000,
         );
         // crate ifaddress object
-        let ifaddress = IfAddress::new("GE1/1/0".to_owned(), "10.0.0.1".parse().unwrap(), 30, 987, 13);
+        let ifaddress = IfAddress::new(
+            "GE1/1/0".to_owned(),
+            "10.0.0.1".parse().unwrap(),
+            30,
+            987,
+            13,
+        );
 
         // wrap them as objects and add them to the response
         let object1 = RpcObject::Rmac(rmac);
@@ -290,8 +289,7 @@ mod positive_tests {
     #[test]
     fn test_rpcmsg_request_get_with_empty_filter() {
         let filter = GetFilter::default();
-        let req = RpcRequest::new(RpcOp::Get, 11223344)
-        .set_object(RpcObject::GetFilter(filter));
+        let req = RpcRequest::new(RpcOp::Get, 11223344).set_object(RpcObject::GetFilter(filter));
 
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
@@ -303,8 +301,7 @@ mod positive_tests {
             otype: vec![ObjType::IpRoute, ObjType::IfAddress, ObjType::Rmac],
             vrfid: vec![11, 21, 31, 41],
         };
-        let req = RpcRequest::new(RpcOp::Get, 13)
-        .set_object(RpcObject::GetFilter(filter));
+        let req = RpcRequest::new(RpcOp::Get, 13).set_object(RpcObject::GetFilter(filter));
         let msg = req.wrap_in_msg();
         test_encode_decode_msg(&msg);
     }

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -79,7 +79,6 @@ fn put_string(buf: &mut BytesMut, string: &String) -> Result<(), WireError> {
     }
 }
 
-
 impl SafeReads for Bytes {
     #[rustfmt::skip]
     fn sget_u8(&mut self, hint: &'static str) -> Result<u8, WireError> {
@@ -594,7 +593,6 @@ impl Wire<RpcNotification> for RpcNotification {
         Ok(())
     }
 }
-
 
 /* RpcMsg and MsgType */
 impl Wire<MsgType> for MsgType {


### PR DESCRIPTION
Implement `std::fmt::Display` for the distinct RpcObjects and RpcMsgs so that we can have simpler logs instead of logs with Debug formatting.

Plus ran cargo fmt.

Samples for Request messages (which call the formatters of the inner objects):

```
Request #36 Add IpRoute ─── vrf:6 tbl:1002 Bgp[200/0] 192.168.70.0/24  via  7.0.0.3 ifindex:7 vrfid: 6 encap: Vxlan (vni:4000)
```
Or
```
Request #24 Add Rmac ─── VNI: 3000 IP: 7.0.0.1 MAC: 1E:F0:35:3B:5F:D1
```
Or
```
Request #11 Add IfAddress ─── ifname: lo IP: 7.0.0.100/32 ifindex: 1 vrfId: 0
```
Or
```
Request #1 Connect Verinfo ─── v0.1.0
```