### PR TITLE
Add sentinels to some enums.

### DIFF
--- a/clib/src/display.c
+++ b/clib/src/display.c
@@ -66,8 +66,8 @@ const char *str_rescode(RpcResultCode code)
         return "Ok";
     case Failure:
         return "Failure";
-    case InvalidOperation:
-        return "InvalidOperation";
+    case InvalidRequest:
+        return "InvalidRequest";
     case ExpectMore:
         return "ExpectMore";
     default:

--- a/clib/src/proto.h
+++ b/clib/src/proto.h
@@ -73,6 +73,7 @@ enum ObjType {
   Rmac = 3,
   IpRoute = 4,
   GetFilter = 5,
+  MaxObjType,
 };
 typedef uint8_t ObjType;
 
@@ -98,6 +99,7 @@ enum RpcOp {
   Del = 3,
   Update = 4,
   Get = 5,
+  MaxRpcOp,
 };
 typedef uint8_t RpcOp;
 
@@ -107,8 +109,9 @@ typedef uint8_t RpcOp;
 enum RpcResultCode {
   Ok = 1,
   Failure = 2,
-  InvalidOperation = 3,
-  ExpectMore = 4,
+  ExpectMore = 3,
+  InvalidRequest = 4,
+  RpcResultCodeMax,
 };
 typedef uint8_t RpcResultCode;
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -28,8 +28,9 @@ pub enum MsgType {
 pub enum RpcResultCode {
     Ok = 1,
     Failure = 2,
-    InvalidOperation = 3,
-    ExpectMore = 4,
+    ExpectMore = 3,
+    InvalidRequest = 4,
+    RpcResultCodeMax, /* sentinel, keep last */
 }
 
 #[doc = "Ip version for an address or prefix. None if not present."]
@@ -51,6 +52,7 @@ pub enum RpcOp {
     Del = 3,
     Update = 4,
     Get = 5,
+    MaxRpcOp, /* sentinel, keep last */
 }
 
 #[doc = "The type of object that a request operation refers to, such as a route."]
@@ -64,6 +66,7 @@ pub enum ObjType {
     Rmac = 3,
     IpRoute = 4,
     GetFilter = 5,
+    MaxObjType, /* sentinel, keep last */
 }
 
 #[doc = "A type of route."]

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -489,6 +489,7 @@ impl Wire<Option<RpcObject>> for RpcObject {
             ObjType::IpRoute => Some(RpcObject::IpRoute(IpRoute::decode(buf)?)),
             ObjType::GetFilter => Some(RpcObject::GetFilter(GetFilter::decode(buf)?)),
             ObjType::None => None,
+            _ => return Err(WireError::InvalidObjTtype(otype as u8))
         };
         Ok(obj)
     }


### PR DESCRIPTION
Having sentinels is convenient in the C code. Manually add some sentinels in proto.rs so that they get added to the C enums in clib/src/proto.h. Cbindgen can automatically do that, but opted for manual addition since we may not need/want all enums to have sentinels. Also, with the current RenameRule in the EnumConfig of cbindgen that we use in build.rs, the added sentinel is called "Sentinel" for all enums, which causes duplicate definitions since we opted not to prefix enum variants with the name of the enum.